### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: API Test


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/4](https://github.com/xdoubleu/check-in/security/code-scanning/4)

To fix the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow does not appear to require write access to the repository, the permissions can be set to `contents: read`. This ensures that the workflow adheres to the principle of least privilege while still functioning correctly.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. If specific jobs require additional permissions, they can override the root-level permissions with their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
