### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: API Lint


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/5](https://github.com/xdoubleu/check-in/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs linting tasks, it requires read-only access to the repository contents. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as no job-specific permissions are needed. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
