### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
     name: API Lint Workflow
     uses: ./.github/workflows/api-lint.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-lint:
@@ -30,6 +32,8 @@ jobs:
     name: Web Lint Workflow
     uses: ./.github/workflows/web-lint.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
 
   api-test:
@@ -37,6 +41,8 @@ jobs:
     name: API Test Workflow
     uses: ./.github/workflows/api-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-test:
@@ -44,5 +50,7 @@ jobs:
     name: Web Test Workflow
     uses: ./.github/workflows/web-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
 


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/6](https://github.com/xdoubleu/check-in/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to each of the jobs (`api-lint`, `web-lint`, `api-test`, and `web-test`) that currently lack it. Since these jobs are likely performing linting and testing tasks, they should only require `contents: read` permissions. This ensures that the jobs have the minimal permissions necessary to function while adhering to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
