### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
     name: API Lint Workflow
     uses: ./.github/workflows/api-lint.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-lint:
@@ -30,6 +32,8 @@ jobs:
     name: Web Lint Workflow
     uses: ./.github/workflows/web-lint.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
 
   api-test:
@@ -37,6 +41,8 @@ jobs:
     name: API Test Workflow
     uses: ./.github/workflows/api-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-test:
@@ -44,5 +50,7 @@ jobs:
     name: Web Test Workflow
     uses: ./.github/workflows/web-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
 


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/7](https://github.com/xdoubleu/check-in/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to each job that currently lacks one (`api-lint`, `web-lint`, `api-test`, `web-test`). These permissions will be set to the least privilege required for the job to function. For linting and testing jobs, `contents: read` is typically sufficient unless they perform actions requiring additional permissions. The `build` job already has explicit permissions defined, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
