### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
     name: API Test Workflow
     uses: ./.github/workflows/api-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-test:


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/8](https://github.com/xdoubleu/check-in/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the `api-test` job. This block should specify the minimal permissions required for the job to function correctly. Based on the provided workflow, the `api-test` job likely only needs `contents: read` permissions, as it does not appear to perform any write operations. If additional permissions are required, they should be added explicitly and minimally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
