### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
     name: API Lint Workflow
     uses: ./.github/workflows/api-lint.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-lint:
@@ -30,6 +32,8 @@ jobs:
     name: Web Lint Workflow
     uses: ./.github/workflows/web-lint.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
 
   api-test:
@@ -37,6 +41,8 @@ jobs:
     name: API Test Workflow
     uses: ./.github/workflows/api-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
     
   web-test:
@@ -44,5 +50,7 @@ jobs:
     name: Web Test Workflow
     uses: ./.github/workflows/web-test.yml
     secrets: inherit
+    permissions:
+      contents: read
     if: needs.build.outputs.committed_generated_files == 'false'
 


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/9](https://github.com/xdoubleu/check-in/security/code-scanning/9)

To fix the issue, we will add an explicit `permissions` block to the `web-test` job. Since the job does not appear to require write permissions based on the provided code, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the job adheres to the principle of least privilege.

We will also add explicit `permissions` blocks to the other jobs (`api-lint`, `web-lint`, and `api-test`) that currently lack them, for consistency and security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
