### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -1,5 +1,8 @@
 name: Web Lint Workflow
 
+permissions:
+  contents: read
+
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,4 +23,3 @@ jobs:
         working-directory: './web'
       - run: yarn lint
         working-directory: './web'
-


### PR DESCRIPTION
Potential fix for [https://github.com/xdoubleu/check-in/security/code-scanning/10](https://github.com/xdoubleu/check-in/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs linting tasks, it requires minimal permissions. The `contents: read` permission is sufficient for accessing the repository files needed for linting. This permission should be added at the root level of the workflow to apply to all jobs, as there is only one job (`lint`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
